### PR TITLE
Add support for AVERAGE-BANDWIDTH property

### DIFF
--- a/Source/M3U8TagsAndAttributes.h
+++ b/Source/M3U8TagsAndAttributes.h
@@ -203,6 +203,7 @@
 #define M3U8_EXT_X_STREAM_INF               @"#EXT-X-STREAM-INF:"
 // EXT-X-STREAM-INF Attributes
 #define M3U8_EXT_X_STREAM_INF_BANDWIDTH     @"BANDWIDTH" // The value is a decimal-integer of bits per second.
+#define M3U8_EXT_X_STREAM_INF_AVERAGE_BANDWIDTH @"AVERAGE-BANDWIDTH" // The value is a decimal-integer of bits per second. It represents the average segment bit rate of the Variant Stream.
 #define M3U8_EXT_X_STREAM_INF_PROGRAM_ID    @"PROGRAM-ID"   // The value is a decimal-integer that uniquely identifies a particular presentation within the scope of the Playlist file.
 #define M3U8_EXT_X_STREAM_INF_CODECS        @"CODECS" // The value is a quoted-string containing a comma-separated list of formats.
 #define M3U8_EXT_X_STREAM_INF_RESOLUTION    @"RESOLUTION" // The value is a decimal-resolution describing the approximate encoded horizontal and vertical resolution of video within the presentation.

--- a/Source/Master Playlist/M3U8ExtXStreamInf.h
+++ b/Source/Master Playlist/M3U8ExtXStreamInf.h
@@ -48,6 +48,7 @@ NSString * NSStringFromMediaResolution(MediaResoulution resolution);
 @interface M3U8ExtXStreamInf : NSObject
 
 @property (nonatomic, readonly, assign) NSInteger bandwidth;
+@property (nonatomic, readonly, assign) NSInteger averageBandwidth;
 @property (nonatomic, readonly, assign) NSInteger programId;        // removed by draft 12
 @property (nonatomic, readonly, copy) NSArray *codecs;
 @property (nonatomic, readonly) MediaResoulution resolution;

--- a/Source/Master Playlist/M3U8ExtXStreamInf.m
+++ b/Source/Master Playlist/M3U8ExtXStreamInf.m
@@ -67,6 +67,10 @@ MediaResoulution MediaResolutionMake(float width, float height) {
     return [self.dictionary[M3U8_EXT_X_STREAM_INF_BANDWIDTH] integerValue];
 }
 
+- (NSInteger)averageBandwidth {
+    return [self.dictionary[M3U8_EXT_X_STREAM_INF_AVERAGE_BANDWIDTH] integerValue];
+}
+
 - (NSInteger)programId {
     return [self.dictionary[M3U8_EXT_X_STREAM_INF_PROGRAM_ID] integerValue];
 }

--- a/Source/Master Playlist/M3U8ExtXStreamInf.m
+++ b/Source/Master Playlist/M3U8ExtXStreamInf.m
@@ -111,7 +111,7 @@ MediaResoulution MediaResolutionMake(float width, float height) {
 }
 
 /*
- #EXT-X-STREAM-INF:AUDIO="600k",BANDWIDTH=1049794,PROGRAM-ID=1,CODECS="avc1.42c01e,mp4a.40.2",RESOLUTION=640x360,SUBTITLES="subs"
+ #EXT-X-STREAM-INF:AUDIO="600k",BANDWIDTH=1049794,AVERAGE-BANDWIDTH=1000000,PROGRAM-ID=1,CODECS="avc1.42c01e,mp4a.40.2",RESOLUTION=640x360,SUBTITLES="subs"
  main_media_0.m3u8
  */
 - (NSString *)m3u8PlanString {
@@ -122,6 +122,10 @@ MediaResoulution MediaResolutionMake(float width, float height) {
         [str appendString:[NSString stringWithFormat:@",BANDWIDTH=%ld", (long)self.bandwidth]];
     } else {
         [str appendString:[NSString stringWithFormat:@"BANDWIDTH=%ld", (long)self.bandwidth]];
+    }
+    
+    if (self.averageBandwidth > 0) {
+        [str appendString:[NSString stringWithFormat:@",AVERAGE-BANDWIDTH=%ld", (long)self.averageBandwidth]];
     }
     
     [str appendString:[NSString stringWithFormat:@",PROGRAM-ID=%ld", (long)self.programId]];


### PR DESCRIPTION
While BANDWIDTH represents the peak bandwidth, AVERAGE-BANDWIDTH is the average.

From HLS spec:
The value is a decimal-integer of bits per second. It represents the average segment bit rate of the Variant Stream.