### PR TITLE
Fix CRLF handling when reading master playlist

### DIFF
--- a/Source/M3U8MasterPlaylist.m
+++ b/Source/M3U8MasterPlaylist.m
@@ -106,7 +106,7 @@
         }
         
         
-        // 简单地忽略掉下面这个Tag
+        // Simply ignore the following tag
         // #EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=65531,PROGRAM-ID=1,CODECS="avc1.42c00c",RESOLUTION=320x180,URI="/talks/769/video/64k_iframe.m3u8?sponsor=Ripple"
         else if ([line hasPrefix:M3U8_EXT_X_I_FRAME_STREAM_INF]) {
             
@@ -162,7 +162,7 @@
         }
     }
     
-    // 暂时只有在分辨率选择的时候用到
+    // For the time being, it is only used when the resolution is selected.
     //    M3U8ExtXMediaList *xmlist = self.masterPlaylist.xMediaList.videoList;
     //    for (int i = 0; i < xmlist.count; i ++) {
     //        M3U8ExtXMedia *media = [xmlist extXMediaAtIndex:i];

--- a/Source/M3U8MediaPlaylist.m
+++ b/Source/M3U8MediaPlaylist.m
@@ -74,12 +74,12 @@
     BOOL isLive = [self.originalText rangeOfString:M3U8_EXT_X_ENDLIST].location == NSNotFound;
     self.isLive = isLive;
     
-    M3U8LineReader* lines = [[M3U8LineReader alloc] initWithText:self.originalText];
+    M3U8LineReader* reader = [[M3U8LineReader alloc] initWithText:self.originalText];
     M3U8ExtXKey *key = nil;
     
     while (true) {
         
-        NSString* line = [lines next];
+        NSString* line = [reader next];
         if (!line) {
             break;
         }
@@ -99,14 +99,13 @@
         }
         
         //check if it's #EXTINF:
-        if ([line hasPrefix:M3U8_EXTINF])
-        {
+        if ([line hasPrefix:M3U8_EXTINF]) {
             line = [line stringByReplacingOccurrencesOfString:M3U8_EXTINF withString:@""];
             line = [line stringByReplacingOccurrencesOfString:@"," withString:@""];
             [params setValue:line forKey:M3U8_EXTINF_DURATION];
             
             //then get URI
-            NSString *nextLine = [lines next];
+            NSString *nextLine = [reader next];
             [params setValue:nextLine forKey:M3U8_EXTINF_URI];
             
             M3U8SegmentInfo *segment = [[M3U8SegmentInfo alloc] initWithDictionary:params xKey:key];

--- a/Source/NSString+m3u8.h
+++ b/Source/NSString+m3u8.h
@@ -18,8 +18,6 @@
 
 - (M3U8SegmentInfoList *)m3u8SegementInfoListValueRelativeToURL:(NSString *)baseURL;
 
-- (NSString *)stringByRemoveReturnCharacter;
-
 /**
  @return "key=value" transform to dictionary
  */

--- a/Source/NSString+m3u8.m
+++ b/Source/NSString+m3u8.m
@@ -124,11 +124,6 @@
     return segmentInfoList;
 }
 
-- (NSString *)stringByRemoveReturnCharacter {
-    NSString *string = [self stringByTrimmingCharactersInSet:NSCharacterSet.newlineCharacterSet];
-    return string;
-}
-
 - (NSString *)stringByRemovingEdgeQuoteMark {
     NSCharacterSet *quoteMarkCharactersSet = [NSCharacterSet characterSetWithCharactersInString:@"\"'"];
     NSString *string = [self stringByTrimmingCharactersInSet:quoteMarkCharactersSet];


### PR DESCRIPTION
Use M3U8LineReader when reading master playlist.

The existing logic breaks when `\r` is present in the playlist. There was special handling for the URI line, but in certain cases (example: audio stream with URI at the end) it broke other lines too.

M3U8LineReader is already used when reading media playlists and solves the issue in a clean way.