### PR TITLE
Fix exporting Swift Package Manager package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,8 @@ let package = Package(
                 "Source/M3U8MediaPlaylist.m",
                 "Source/M3U8SegmentInfo.m",
                 "Source/M3U8SegmentInfoList.m",
+                "Source/M3U8ExtXByteRange.m",
+                
             ],
             publicHeadersPath: "include",
             cxxSettings: [

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,6 @@ let package = Package(
                 "Source/M3U8SegmentInfo.m",
                 "Source/M3U8SegmentInfoList.m",
                 "Source/M3U8ExtXByteRange.m",
-                
             ],
             publicHeadersPath: "include",
             cxxSettings: [


### PR DESCRIPTION
I had an issue while importing M3U8Parser into my project

<img width="562" alt="Zrzut ekranu 2020-12-22 o 14 37 58" src="https://user-images.githubusercontent.com/34795945/102894384-4c732e00-4463-11eb-8f8e-1f655abf0a72.png">

I found that `M3U8ExtXByteRange.m` weren't specified in the target sources list in Package file. After adding that path, the error is gone.
